### PR TITLE
Adding noarch_python option to builds

### DIFF
--- a/derapproximator/meta.yaml
+++ b/derapproximator/meta.yaml
@@ -13,6 +13,7 @@ source:
     - move_version.patch
 
 build:
+  noarch_python: True
   number: {{ environ.get("APPVEYOR_BUILD_NUMBER", 1) }} [win]
 
 requirements:

--- a/funcdesigner/meta.yaml
+++ b/funcdesigner/meta.yaml
@@ -10,6 +10,7 @@ source:
     - fix_generator35.patch
 
 build:
+  noarch_python: True
   number: {{ environ.get("APPVEYOR_BUILD_NUMBER", 1) }} [win]
 
 requirements:

--- a/openopt/meta.yaml
+++ b/openopt/meta.yaml
@@ -11,6 +11,7 @@ source:
     #- fix.patch
 
 build:
+  noarch_python: True
   number: {{ environ.get("APPVEYOR_BUILD_NUMBER", 1) }} [win]
 
 requirements:

--- a/pyomo.extras/meta.yaml
+++ b/pyomo.extras/meta.yaml
@@ -13,6 +13,9 @@ source:
 build:
   number: {{ environ.get("APPVEYOR_BUILD_NUMBER", 1) }} [win]
 
+build:
+  noarch_python: True
+
 requirements:
   build:
     - python

--- a/pyomo.extras/meta.yaml
+++ b/pyomo.extras/meta.yaml
@@ -11,10 +11,8 @@ source:
    # - fix.patch
 
 build:
-  number: {{ environ.get("APPVEYOR_BUILD_NUMBER", 1) }} [win]
-
-build:
   noarch_python: True
+  number: {{ environ.get("APPVEYOR_BUILD_NUMBER", 1) }} [win]
 
 requirements:
   build:

--- a/pyomo/meta.yaml
+++ b/pyomo/meta.yaml
@@ -11,6 +11,7 @@ source:
     - fix_neos.patch
 
 build:
+  noarch_python: True
   number: {{ environ.get("APPVEYOR_BUILD_NUMBER", 1) }} [win]
 
   preserve_egg_dir: True

--- a/pyutilib/meta.yaml
+++ b/pyutilib/meta.yaml
@@ -8,6 +8,7 @@ source:
   md5: 0c0d54632c70427c84a21d31f56c1a5b
 
 build:
+  noarch_python: True
   number: {{ environ.get("APPVEYOR_BUILD_NUMBER", 1) }} [win]
 
   preserve_egg_dir: True

--- a/serpent/meta.yaml
+++ b/serpent/meta.yaml
@@ -8,6 +8,7 @@ source:
   md5: 05869ac7b062828b34f8f927f0457b65
 
 build:
+  noarch_python: True
   number: {{ environ.get("APPVEYOR_BUILD_NUMBER", 1) }} [win]
 
 requirements:

--- a/setproctitle/meta.yaml
+++ b/setproctitle/meta.yaml
@@ -8,6 +8,7 @@ source:
   md5: 95d9e56c69437246460a20804961d70d
 
 build:
+  noarch_python: True
   number: {{ environ.get("APPVEYOR_BUILD_NUMBER", 1) }} [win]
 
 requirements:

--- a/suds-jurko/meta.yaml
+++ b/suds-jurko/meta.yaml
@@ -8,6 +8,7 @@ source:
   md5: 1309e9bc2454aa3434041f0a24ae4e11
 
 build:
+  noarch_python: True
   number: {{ environ.get("APPVEYOR_BUILD_NUMBER", 1) }} [win]
 
 requirements:


### PR DESCRIPTION
This allows builds for pure Python packages to support multiple Python versions.
